### PR TITLE
Re-sort table data if __tsort_rebuild is set

### DIFF
--- a/tsort.js
+++ b/tsort.js
@@ -82,9 +82,16 @@ Array - Specifc table
 			/* GET TABLE DATA */
 			function getTableData() {
 				
+                var tlength = $(table).find('tr').length;
 				/* PUT TABLE DATA INTO AN OBJECT ARRAY */
 				$(table).find('tr').each(function(index) {
-					if (index > 0) $(this).addClass('tsort_id-' + (index - 1)); // Add a class to each tr that corresponds with the object id (tsortid-0)
+                   if (index > 0) $(this).removeClass(function(){
+                        var allclasses = "";
+                        for(var i=0; i<= tlength ;i++){
+                            allclasses = allclasses+"tsort_id-"+i+" ";
+                        }
+                        return allclasses;
+                    }).addClass('tsort_id-' + (index - 1)); // Add a class to each tr that corresponds with the object id (tsortid-0)
 					$(this).find('td').each(function (td_index) {
 						if ($(this).is(":first-child")) {
 							table_data.push(new Object());
@@ -195,9 +202,20 @@ Array - Specifc table
 				if (table_data.length == 0) { // Get the table data if we haven't already
 					getTableData();
 				}
+                if(typeof rebuild != 'undefined' && rebuild){
+                    if(rebuild){
+                       table_data = new Array();  // Original table data
+                        table_data.length = 0;
+                        sorted_table_data = new Array(); // To contain sorted tables
+                        sorted_table_data.length = 0;
+                       sorting_history = new Array();
+                        sorting_history.length = 0;
+                       getTableData();
+                    }
+                }
 				
 				if (!sorted_table_data[th_index_selected]) {	// If we haven't sorted this column yet
-						sorted_table_data[th_index_selected] = table_data.concat(); // Make a copy of the original table data
+				    sorted_table_data[th_index_selected] = table_data.concat(); // Make a copy of the original table data
 					if (sorting_criteria[th_index_selected] == 'numeric') {		// Sort numeric
 						sorted_table_data[th_index_selected].sort(function(a,b) {
 							return a.td[th_index_selected] - b.td[th_index_selected];

--- a/tsort.js
+++ b/tsort.js
@@ -202,8 +202,8 @@ Array - Specifc table
 				if (table_data.length == 0) { // Get the table data if we haven't already
 					getTableData();
 				}
-                if(typeof rebuild != 'undefined' && rebuild){
-                    if(rebuild){
+                if(typeof __tsort_rebuild != 'undefined' && __tsort_rebuild){
+                    if(__tsort_rebuild){
                        table_data = new Array();  // Original table data
                         table_data.length = 0;
                         sorted_table_data = new Array(); // To contain sorted tables
@@ -275,11 +275,18 @@ Array - Specifc table
 			
 			// This function receives the new sorted table data array and displays it
 			function display_table(data, direction) {
-				if (direction == 'ascending') {
-					var data = data.concat(); // .concat() fixes function scope issues with references by saving a copy of it (function within function loading old data)
-				} else {
-					var data = data.concat().reverse();
-				}
+                if(typeof __tsort_direction != 'undefined'){
+                	if (__tsort_direction == 'ascending') {
+                    	var data = data.concat(); // .concat() fixes function scope issues with references by saving a copy of it (function within function loading old data)
+                	} else {
+                    	var data = data.concat().reverse();
+                	}
+                }
+                else if (direction == 'ascending') {
+                    var data = data.concat(); // .concat() fixes function scope issues with references by saving a copy of it (function within function loading old data)
+                } else {
+                    var data = data.concat().reverse();
+                }
 				
 				vertical_offset = $(table).find('tr').height(); // Start at header height
 				


### PR DESCRIPTION
Why?
I'm trying to use tsort to implement a real-time monitor system. Ajax is used to update data in the table. After updated, the old version tsort would not re-sort table.

How?
A new variable "__tsort_rebuild"  is added to fix this. Once "__tsort_rebuild" is defined, ervery time you click the resort button(&lt;th&gt;...&lt;/th&gt;), tsort will try resort data with function "getTableData".

Code Sample

``` javascript
var __tsort_rebuild = 1;
var __tsort_direction = "descending";

setInterval("autosort()",3000);

function autosort(){
    $.ajax(
        {
            .......
            error: function(){
                ....
            },
            success: function(realdata){
                ... update data in table ...
                // resort
            }
        }
    );
    $("#sorttable").find('#th_id').first().trigger('click');
}
```

Demo: [MySQL Realtime Status](http://www.orczhou.com/tsort/) 
